### PR TITLE
fix: Fix unbound font_threshold and Improve error handling.

### DIFF
--- a/lyrapdf/app.py
+++ b/lyrapdf/app.py
@@ -150,6 +150,8 @@ def extract_and_process(input_dir, pdf_path, json_output):
 		print("PDFSyntaxError: Is this really a PDF? ", pdf_path)
 	except PDFTextExtractionNotAllowed as e:
 		print(e)
+	except Exception as e:
+		print(e)
 
 
 def get_file_list(input_dir):

--- a/lyrapdf/pre_proc.py
+++ b/lyrapdf/pre_proc.py
@@ -301,6 +301,7 @@ def analyze_font_size(text):
 	total = sum(font_size_dict.values())
 	percentage_sum = 0
 	max_quote = 0
+	font_threshold = 0
 	i = 0 # Keep track of the index
 	for key in sorted_font_size_dict:
 		# Update accumulated percentage


### PR DESCRIPTION
- Initialize `font_threshold` variable after use it
- Improve exception handling

[lyrapdf/pre_proc.py]()
- Add `font_threshold` variable to `analyze_font_size` function  

[lyrapdf/app.py]()
- Add exception handling to the extract_and_process function